### PR TITLE
Fixed an issue where on linux using jme-lwjgl3 module would cause the…

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -149,7 +149,7 @@ public final class NativeLibraryLoader {
         registerNativeLibrary("glfw-lwjgl3", Platform.Windows32, "native/windows/glfw32.dll");
         registerNativeLibrary("glfw-lwjgl3", Platform.Windows64, "native/windows/glfw.dll");
         registerNativeLibrary("glfw-lwjgl3", Platform.Linux32, "native/linux/libglfw32.so");
-        registerNativeLibrary("glfw-lwjgl3", Platform.Linux64, "native/linux/libglfw.dll");
+        registerNativeLibrary("glfw-lwjgl3", Platform.Linux64, "native/linux/libglfw.so");
         registerNativeLibrary("glfw-lwjgl3", Platform.MacOSX32, "native/macosx/libglfw.dylib");
         registerNativeLibrary("glfw-lwjgl3", Platform.MacOSX64, "native/macosx/libglfw.dylib");
 


### PR DESCRIPTION
… windows dll to be loaded instead of the linux so native library.